### PR TITLE
support text fade effect in firefox

### DIFF
--- a/app/containers/AllProposals.jsx
+++ b/app/containers/AllProposals.jsx
@@ -203,7 +203,17 @@ class AllProposals extends Component {
       return (
           <BaseLayout currentPath={this.props.location.pathname} name="all-proposals">
             <NotificationSystem ref="notificationSystem" style={{ NotificationItem: { DefaultStyle: { marginTop: '120px', padding: '20px' } } } } />
-
+            <svg width="0" height="0" viewBox="0 0 2000 80">
+              <defs>
+                <mask id="textFade">
+                  <linearGradient id="gradient" x1="0" x2="0" y1="0" y2="100%">
+                    <stop offset="0.5" stopColor="white" />
+                    <stop offset="1" stopColor="black" stopOpacity="0.5"/>
+                  </linearGradient>
+                  <rect x="0" y="0" width="100%" height="100%" fill="url(#gradient)"/>
+                </mask>
+              </defs>
+            </svg>
             <Rodal  visible={this.state.editingSession}
                     width={700}
                     height={600}

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -109,14 +109,14 @@ ul.with-bullets ul {
   overflow: hidden;
 
   /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#ffffff+0,ffffff+100&0.01+0,1+100 */
-  -moz-mask-image: -moz-linear-gradient(top,  rgba(255,255,255,1) 0%, rgba(255,255,255,0.01) 100%); /* FF3.6-15 */
-  -webkit-mask-image: -webkit-linear-gradient(top,  rgba(255,255,255,1) 0%,rgba(255,255,255,0.01) 100%); /* Chrome10-25,Safari5.1-6 */
-  mask-image: linear-gradient(to bottom,  rgba(255,255,255,1) 0%,rgba(255,255,255,0.01) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+  mask: url(#textFade); /* works only in firefox */
+  -webkit-mask-image: -webkit-linear-gradient(top,  rgba(255,255,255,1) 50%,rgba(255,255,255,0.01) 100%); /* Chrome10-25,Safari5.1-6 */
+  mask-image: linear-gradient(to bottom,  rgba(255,255,255,1) 50%,rgba(255,255,255,0.01) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 }
 
 .proposal-preview-expanded .proposal-content-container {
   /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#ffffff+0,ffffff+100&0.01+0,1+100 */
-  -moz-mask-image: -moz-linear-gradient(top,  rgba(255,255,255,1) 0%, rgba(255,255,255,1) 100%); /* FF3.6-15 */
+  mask: none; /* works only in firefox */
   -webkit-mask-image: -webkit-linear-gradient(top,  rgba(255,255,255,1) 0%,rgba(255,255,255,1) 100%); /* Chrome10-25,Safari5.1-6 */
   mask-image: linear-gradient(to bottom,  rgba(255,255,255,1) 0%,rgba(255,255,255,1) 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
 }


### PR DESCRIPTION
mask-\* longhand properties are not supported in firefox yet, and only svg masks are supported in firefox (https://bugzilla.mozilla.org/show_bug.cgi?id=1251161).
Unfortunately chrome **doesn't** support svg masks (http://codepen.io/SitePoint/pen/xVMwmb), so two different methods for masks in css.
Also, I refined the text fade to start only at the very bottom of the second row, not from the very top.
